### PR TITLE
Handle default rectangle exceeds datatype capacity

### DIFF
--- a/QuadTrees/Common/QuadTreeCommon.cs
+++ b/QuadTrees/Common/QuadTreeCommon.cs
@@ -31,8 +31,10 @@ namespace QuadTrees.Common
         /// </summary>
         protected QuadTreeCommon()
         {
+            int maxDimension = (int)Math.Sqrt(int.MaxValue);
+            int minDimension = -(int)Math.Sqrt(Math.Abs(int.MinValue));
             QuadTreePointRoot =
-                CreateNode(new Rectangle(int.MinValue / 2, int.MinValue / 2, int.MaxValue, int.MaxValue));
+                CreateNode(new Rectangle(minDimension / 2, minDimension / 2, maxDimension, maxDimension));
         }
 
         /// <summary>

--- a/QuadTrees/Common/QuadTreeFCommon.cs
+++ b/QuadTrees/Common/QuadTreeFCommon.cs
@@ -31,8 +31,12 @@ namespace QuadTrees.Common
         /// </summary>
         protected QuadTreeFCommon()
         {
+
+            float maxDimension = (float)Math.Sqrt(float.MaxValue);
+            float minDimension = -(float)Math.Sqrt(Math.Abs(float.MinValue));
+
             QuadTreePointRoot =
-                CreateNode(new RectangleF(float.MinValue/2, float.MinValue/2, float.MaxValue, float.MaxValue));
+                CreateNode(new RectangleF(minDimension / 2, minDimension / 2, maxDimension, maxDimension));
         } 
 
         /// <summary>

--- a/QuadTrees/QuadTreePoint.cs
+++ b/QuadTrees/QuadTreePoint.cs
@@ -31,6 +31,7 @@ namespace QuadTrees
 
         protected override QuadTreePointNode<T> CreateNode(Rectangle rect)
         {
+            System.Diagnostics.Debug.Assert(int.MaxValue > (rect.Width * rect.Height), "Node rectangle area datatype capacity");
             return new QuadTreePointNode<T>(rect);
         }
     }

--- a/QuadTrees/QuadTreePointF.cs
+++ b/QuadTrees/QuadTreePointF.cs
@@ -31,6 +31,7 @@ namespace QuadTrees
 
         protected override QuadTreePointFNode<T> CreateNode(RectangleF rect)
         {
+            System.Diagnostics.Debug.Assert(!float.IsInfinity(rect.Width * rect.Height), "Node rectangle area datatype capacity");
             return new QuadTreePointFNode<T>(rect);
         }
     }

--- a/QuadTrees/QuadTreeRect.cs
+++ b/QuadTrees/QuadTreeRect.cs
@@ -25,6 +25,7 @@ namespace QuadTrees
 
         protected override QuadTreeRectNode<T, Rectangle> CreateNode(Rectangle rect)
         {
+            System.Diagnostics.Debug.Assert(int.MaxValue > (rect.Width * rect.Height) , "Node rectangle area datatype capacity");
             return new QuadTreeRectNode<T>(rect);
         }
     }

--- a/QuadTrees/QuadTreeRectF.cs
+++ b/QuadTrees/QuadTreeRectF.cs
@@ -24,6 +24,7 @@ namespace QuadTrees
 
         protected override QuadTreeRectNode<T, RectangleF> CreateNode(RectangleF rect)
         {
+            System.Diagnostics.Debug.Assert(!float.IsInfinity(rect.Width * rect.Height), "Node rectangle area datatype capacity");
             return new QuadTreeRectFNode<T>(rect);
         }
     }

--- a/QuadTrees/QuadTreeRectPointFInverse.cs
+++ b/QuadTrees/QuadTreeRectPointFInverse.cs
@@ -24,6 +24,7 @@ namespace QuadTrees
 
         protected override QuadTreeRectNode<T, PointF> CreateNode(RectangleF rect)
         {
+            System.Diagnostics.Debug.Assert(!float.IsInfinity(rect.Width * rect.Height), "Node rectangle area datatype capacity");
             return new QuadTreeRectPointFInvNode<T>(rect);
         }
     }

--- a/QuadTrees/QuadTreeRectPointInverse.cs
+++ b/QuadTrees/QuadTreeRectPointInverse.cs
@@ -25,6 +25,7 @@ namespace QuadTrees
 
         protected override QuadTreeRectNode<T, Point> CreateNode(Rectangle rect)
         {
+            System.Diagnostics.Debug.Assert(int.MaxValue > (rect.Width * rect.Height), "Node rectangle area datatype capacity");
             return new QuadTreeRectPointInvNode<T>(rect);
         }
     }


### PR DESCRIPTION
Regarding the infinity problem in defaults. I made this simple fix to check that input rectangle area doesn't exceed the datatype capacity, and initialized the default rectangle so that its area is the Max value instead of its dimensions.
However, this fix adds a little overhead because the first rectangle can be too large for the actual input  and it would take multiple levels with only one quarter populated to reach the balanced level. To resolve this I thought of two suggestions:

1. After constructing the tree, the user can call a function to clean all the levels that have only one quarter occupied and add their objects to the actual most balanced root.
2. I am not sure if it is possible but did you consider removing the defaults? QuadTrees' performance depends on the data to be well distributed around the space, so I think the user should already know the objects boundary. But, like I said, I know this can cause backward compatibility issues and cannot be feasible.



 