### PR TITLE
Switch framework to netstandard2.0

### DIFF
--- a/QuadTrees/QuadTrees.csproj
+++ b/QuadTrees/QuadTrees.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We are using 'QuadTrees' inside a .net Framework 4.6.2 project and  we need a version compatible with it.

Is their any reason to use 'netcoreapp3.1' instead of 'netstandard2.0'?