### PR TITLE
Add 'netstandard2.0' as TargetFramework

### DIFF
--- a/QuadTrees.nuspec
+++ b/QuadTrees.nuspec
@@ -12,8 +12,13 @@
 		<releaseNotes>Automatic Updates via GitHub</releaseNotes>
 		<copyright>Copyright Never</copyright>
 		<language>en-US</language>
+		<dependencies>
+			<group targetFramework=".netcoreapp3.1" />
+			<group targetFramework=".netstandard2.0" />
+		</dependencies>
 	</metadata>
 	<files>
-		<file src="QuadTrees/bin/Release/QuadTrees.dll" target="lib" />
+		<file src="QuadTrees/bin/Release/netcoreapp3.1/QuadTrees.dll" target="lib/netcoreapp3.1" />
+		<file src="QuadTrees/bin/Release/netstandard2.0/QuadTrees.dll" target="lib/netstandard2.0" />
 	</files>
 </package>

--- a/QuadTrees/QuadTrees.csproj
+++ b/QuadTrees/QuadTrees.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
As suggested in https://github.com/splitice/QuadTrees/pull/14 I added 'netstandard2.0' as second build target.