### PR TITLE
Struct support, performance adjustments and some utilities 

### DIFF
--- a/QuadTrees.Tests/QuadTrees.Tests.csproj
+++ b/QuadTrees.Tests/QuadTrees.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +13,7 @@
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QuadTrees.Tests/TestPoint.cs
+++ b/QuadTrees.Tests/TestPoint.cs
@@ -17,8 +17,8 @@ namespace QuadTrees.Tests
         {
             private PointF _rect;
 
-            public PointF Point
-            {
+            public PointF Point {
+                set { _rect = value; }
                 get { return _rect; }
             }
 
@@ -28,19 +28,34 @@ namespace QuadTrees.Tests
             }
         }
         
-        struct QTreeObjectStruct: IPointFQuadStorable
-        {
+        struct QTreeObjectStruct: IPointFQuadStorable {
+
+            public int uniqueId;
             private PointF _rect;
 
             public PointF Point
             {
+                set { _rect = value; }
                 get { return _rect; }
             }
 
-            public QTreeObjectStruct(PointF rect)
-            {
+            public QTreeObjectStruct(int uniqueId, PointF rect) {
+                this.uniqueId = uniqueId;
                 _rect = rect;
             }
+
+            public bool Equals(QTreeObjectStruct other) {
+                return uniqueId == other.uniqueId;
+            }
+
+            public override bool Equals(object obj) {
+                return obj is QTreeObjectStruct other && Equals(other);
+            }
+
+            public override int GetHashCode() {
+                return uniqueId;
+            }
+
         }
         
         public struct Payload {
@@ -196,12 +211,12 @@ namespace QuadTrees.Tests
         public void TestGetObjectsArrayStack() {
 
             var list = new List<QTreeObjectStruct> {
-                new QTreeObjectStruct(new PointF(10, 10)),
-                new QTreeObjectStruct(new PointF(11, 11)),
-                new QTreeObjectStruct(new PointF(100, 10)),
-                new QTreeObjectStruct(new PointF(12, 12)),
-                new QTreeObjectStruct(new PointF(13, 13)),
-                new QTreeObjectStruct(new PointF(-1000, 1000))
+                new QTreeObjectStruct(1,new PointF(10, 10)),
+                new QTreeObjectStruct(2,new PointF(11, 11)),
+                new QTreeObjectStruct(3,new PointF(100, 10)),
+                new QTreeObjectStruct(4,new PointF(12, 12)),
+                new QTreeObjectStruct(5,new PointF(13, 13)),
+                new QTreeObjectStruct(6,new PointF(-1000, 1000))
             };
             
             QuadTreePointF<QTreeObjectStruct> qtree = new QuadTreePointF<QTreeObjectStruct>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
@@ -217,6 +232,42 @@ namespace QuadTrees.Tests
             Assert.AreEqual(array[1], list[1]);
             Assert.AreEqual(array[2], list[3]);
             Assert.AreEqual(array[3], list[4]);
+        }
+        
+        [TestCase]
+        public void TestMove() {
+            
+            var obj = new QTreeObject(new PointF(5, 5));
+            QuadTreePointF<QTreeObject> qtree = new QuadTreePointF<QTreeObject>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(new List<QTreeObject>
+            {
+                obj,
+                new QTreeObject(new PointF(-1000,1000))
+            });
+
+            obj.Point = new PointF(11, 11);
+            qtree.Move(obj);
+
+            var list = qtree.GetObjects(new RectangleF(10, 10, 20, 20));
+            Assert.AreEqual(1, list.Count);
+        }
+        
+        [TestCase]
+        public void TestMoveStruct() {
+            
+            var obj = new QTreeObjectStruct(1,new PointF(5, 5));
+            QuadTreePointF<QTreeObjectStruct> qtree = new QuadTreePointF<QTreeObjectStruct>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(new List<QTreeObjectStruct>
+            {
+                obj,
+                new QTreeObjectStruct(2,new PointF(-1000,1000))
+            });
+
+            obj.Point = new PointF(11, 11);
+            qtree.Move(obj);
+
+            var list = qtree.GetObjects(new RectangleF(10, 10, 20, 20));
+            Assert.AreEqual(1, list.Count);
         }
     }
 }

--- a/QuadTrees.Tests/TestPoint.cs
+++ b/QuadTrees.Tests/TestPoint.cs
@@ -27,6 +27,87 @@ namespace QuadTrees.Tests
                 _rect = rect;
             }
         }
+        
+        struct QTreeObjectStruct: IPointFQuadStorable
+        {
+            private PointF _rect;
+
+            public PointF Point
+            {
+                get { return _rect; }
+            }
+
+            public QTreeObjectStruct(PointF rect)
+            {
+                _rect = rect;
+            }
+        }
+        
+        public struct Payload {
+            public int count;
+        };
+        
+        [TestCase]
+        public void TestCountQuery()
+        {
+            QuadTreePointF<QTreeObject> qtree = new QuadTreePointF<QTreeObject>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(new List<QTreeObject>
+            {
+                new QTreeObject(new PointF(10,10)),
+                new QTreeObject(new PointF(11,11)),
+                new QTreeObject(new PointF(12,12)),
+                new QTreeObject(new PointF(11,11)),
+                new QTreeObject(new PointF(-1000,1000))
+            });
+
+            var list = qtree.GetObjects(new RectangleF(9, 9, 20, 20));
+            var count = qtree.ObjectCount(new RectangleF(9, 9, 20, 20));
+
+            Assert.AreEqual(4, list.Count);
+            Assert.AreEqual(4, count);
+        }
+        
+        [TestCase]
+        public void TestForObject()
+        {
+            QuadTreePointF<QTreeObject> qtree = new QuadTreePointF<QTreeObject>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(new List<QTreeObject>
+            {
+                new QTreeObject(new PointF(10,10)),
+                new QTreeObject(new PointF(11,11)),
+                new QTreeObject(new PointF(12,12)),
+                new QTreeObject(new PointF(11,11)),
+                new QTreeObject(new PointF(-1000,1000))
+            });
+
+            var count = 0;
+            qtree.GetObjects(new RectangleF(9, 9, 20, 20), (ref QTreeObject o) => {
+                count++;
+            });
+            Assert.AreEqual(4, count);
+        }
+        
+        [TestCase]
+        public void TestForObjectPayload()
+        {
+
+            QuadTreePointF<QTreeObject> qtree = new QuadTreePointF<QTreeObject>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(new List<QTreeObject>
+            {
+                new QTreeObject(new PointF(10,10)),
+                new QTreeObject(new PointF(11,11)),
+                new QTreeObject(new PointF(12,12)),
+                new QTreeObject(new PointF(11,11)),
+                new QTreeObject(new PointF(-1000,1000))
+            });
+
+            var payload = new Payload{ count = 0 };
+            qtree.GetObjects(new RectangleF(9, 9, 20, 20), ref payload, (ref Payload p, ref QTreeObject o) => {
+                p.count++;
+            });
+            Assert.AreEqual(4, payload.count);
+        }
+
         [TestCase]
         public void TestListQuery()
         {
@@ -38,8 +119,11 @@ namespace QuadTrees.Tests
             });
 
             var list = qtree.GetObjects(new RectangleF(9, 9, 20, 20));
+            var count = qtree.ObjectCount(new RectangleF(9, 9, 20, 20));
             Assert.AreEqual(1, list.Count);
+            Assert.AreEqual(1, count);
         }
+        
         [TestCase]
         public void TestListQueryOutput()
         {
@@ -79,6 +163,60 @@ namespace QuadTrees.Tests
 
             var list = qtree.GetAllObjects();
             Assert.AreEqual(2, list.Count());
+        }
+
+        [TestCase]
+        public void TestGetObjectsArray() {
+
+            var list = new List<QTreeObject> {
+                new QTreeObject(new PointF(10, 10)),
+                new QTreeObject(new PointF(11, 11)),
+                new QTreeObject(new PointF(100, 10)),
+                new QTreeObject(new PointF(12, 12)),
+                new QTreeObject(new PointF(11, 11)),
+                new QTreeObject(new PointF(-1000, 1000))
+            };
+            
+            QuadTreePointF<QTreeObject> qtree = new QuadTreePointF<QTreeObject>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(list);
+
+            var rect = new RectangleF(9, 9, 20, 20);
+            var count = qtree.ObjectCount(rect);
+            var array = new QTreeObject[count];
+            qtree.GetObjects(rect, array);
+            
+            Assert.AreEqual(4, count);
+            Assert.AreEqual(array[0], list[0]);
+            Assert.AreEqual(array[1], list[1]);
+            Assert.AreEqual(array[2], list[3]);
+            Assert.AreEqual(array[3], list[4]);
+        }
+        
+        [TestCase]
+        public void TestGetObjectsArrayStack() {
+
+            var list = new List<QTreeObjectStruct> {
+                new QTreeObjectStruct(new PointF(10, 10)),
+                new QTreeObjectStruct(new PointF(11, 11)),
+                new QTreeObjectStruct(new PointF(100, 10)),
+                new QTreeObjectStruct(new PointF(12, 12)),
+                new QTreeObjectStruct(new PointF(13, 13)),
+                new QTreeObjectStruct(new PointF(-1000, 1000))
+            };
+            
+            QuadTreePointF<QTreeObjectStruct> qtree = new QuadTreePointF<QTreeObjectStruct>(new RectangleF(float.MinValue/2,float.MinValue/2,float.MaxValue,float.MaxValue));
+            qtree.AddRange(list);
+
+            var rect = new RectangleF(9, 9, 20, 20);
+            var count = qtree.ObjectCount(rect);
+            Span<QTreeObjectStruct> array = stackalloc QTreeObjectStruct[count];
+            qtree.GetObjects(rect, array);
+            
+            Assert.AreEqual(4, count);
+            Assert.AreEqual(array[0], list[0]);
+            Assert.AreEqual(array[1], list[1]);
+            Assert.AreEqual(array[2], list[3]);
+            Assert.AreEqual(array[3], list[4]);
         }
     }
 }

--- a/QuadTrees/Common/QuadTreeCommon.cs
+++ b/QuadTrees/Common/QuadTreeCommon.cs
@@ -156,11 +156,33 @@ namespace QuadTrees.Common
         /// Moves the object in the tree
         /// </summary>
         /// <param name="item">The item that has moved</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Move(TObject item)
         {
             QuadTreeObject<TObject, TNode> obj;
-            if (WrappedDictionary.TryGetValue(item, out obj))
-            {
+            if (WrappedDictionary.TryGetValue(item, out obj)) {
+                
+                obj._data = item;
+                obj.Owner.Relocate(obj);
+
+                Debug.Assert(WrappedDictionary.Count == QuadTreePointRoot.Count);
+                return true;
+            }
+            Debug.Assert(WrappedDictionary.Count == QuadTreePointRoot.Count);
+            return false;
+        }
+        
+        /// <summary>
+        /// Moves the object in the tree
+        /// </summary>
+        /// <param name="item">The item that has moved</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Move(ref TObject item)
+        {
+            QuadTreeObject<TObject, TNode> obj;
+            if (WrappedDictionary.TryGetValue(item, out obj)) {
+                
+                obj._data = item;
                 obj.Owner.Relocate(obj);
 
                 Debug.Assert(WrappedDictionary.Count == QuadTreePointRoot.Count);

--- a/QuadTrees/Common/QuadTreeFCommon.cs
+++ b/QuadTrees/Common/QuadTreeFCommon.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -70,9 +71,42 @@ namespace QuadTrees.Common
         }
 
         /// <summary>
+        /// Counts all the objects within the rect and returns the size
+        /// </summary>
+        /// <param name="rect"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ObjectCount(TQuery rect) {
+            return QuadTreePointRoot.ObjectCount(rect);
+        }
+        
+        /// <summary>
+        /// Queries all entities within the range and provides a delegate to interact with each single object. 
+        /// </summary>
+        /// <param name="rect"></param>
+        /// <param name="add"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetObjects(TQuery rect, ForObject<TObject> add)
+        {
+            QuadTreePointRoot.GetObjects(rect, add);
+        }
+        
+        /// <summary>
+        /// Queries all entities within the range and provides a delegate with payload to interact with each single object. 
+        /// </summary>
+        /// <param name="rect"></param>
+        /// <param name="add"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetObjects<P>(TQuery rect, ref P payload, ForObject<P,TObject> add)
+        {
+            QuadTreePointRoot.GetObjects(rect, ref payload, add);
+        }
+        
+        /// <summary>
         /// Get the objects in this tree that intersect with the specified rectangle.
         /// </summary>
         /// <param name="rect">The RectangleF to find objects in.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public List<TObject> GetObjects(TQuery rect)
         {
             return QuadTreePointRoot.GetObjects(rect);
@@ -83,6 +117,7 @@ namespace QuadTrees.Common
         /// </summary>
         /// <param name="rect"></param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerable<TObject> EnumObjects(TQuery rect)
         {
             return QuadTreePointRoot.EnumObjects(rect);
@@ -94,11 +129,12 @@ namespace QuadTrees.Common
         /// </summary>
         /// <param name="rect">The RectangleF to find objects in.</param>
         /// <param name="results">A reference to a list that will be populated with the results.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GetObjects(TQuery rect, List<TObject> results)
         {
-            Action<TObject> cb = results.Add;
+            ForObject<TObject> cb = (ref TObject o) => results.Add(o);
 #if DEBUG
-            cb = (a) =>
+            cb = (ref TObject a) =>
             {
                 Debug.Assert(!results.Contains(a));
                 results.Add(a);
@@ -106,12 +142,17 @@ namespace QuadTrees.Common
 #endif
             QuadTreePointRoot.GetObjects(rect, cb);
         }
-
-
-        public void GetObjects(TQuery rect, Action<TObject> add)
-        {
-            QuadTreePointRoot.GetObjects(rect, add);
+        
+        /// <summary>
+        /// Get the objects in this tree that intersect with the specified rectangle.
+        /// </summary>
+        /// <param name="rect">The RectangleF to find objects in.</param>
+        /// <param name="results">A reference to a list that will be populated with the results.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetObjects(TQuery rect, Span<TObject> results) {
+            QuadTreePointRoot.GetObjects(rect, results);
         }
+        
 
         /// <summary>
         /// Get all objects in this Quad, and it's children.

--- a/QuadTrees/Common/QuadTreeFCommon.cs
+++ b/QuadTrees/Common/QuadTreeFCommon.cs
@@ -167,11 +167,14 @@ namespace QuadTrees.Common
         /// Moves the object in the tree
         /// </summary>
         /// <param name="item">The item that has moved</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Move(TObject item)
         {
             QuadTreeObject<TObject, TNode> obj;
-            if (WrappedDictionary.TryGetValue(item, out obj))
-            {
+            if (WrappedDictionary.TryGetValue(item, out obj)) {
+                
+                // Update data ( primarly for structs ) and relocate 
+                obj._data = item;
                 obj.Owner.Relocate(obj);
 
                 Debug.Assert(WrappedDictionary.Count == QuadTreePointRoot.Count);
@@ -181,6 +184,27 @@ namespace QuadTrees.Common
             return false;
         }
 
+        /// <summary>
+        /// Moves the object in the tree
+        /// </summary>
+        /// <param name="item">The item that has moved</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Move(ref TObject item)
+        {
+            QuadTreeObject<TObject, TNode> obj;
+            if (WrappedDictionary.TryGetValue(item, out obj)) {
+                
+                // Update data ( primarly for structs ) and relocate 
+                obj._data = item;
+                obj.Owner.Relocate(obj);
+
+                Debug.Assert(WrappedDictionary.Count == QuadTreePointRoot.Count);
+                return true;
+            }
+            Debug.Assert(WrappedDictionary.Count == QuadTreePointRoot.Count);
+            return false;
+        }
+        
         #endregion
 
         #region ICollection<T> Members

--- a/QuadTrees/Common/QuadTreeNodeCommon.cs
+++ b/QuadTrees/Common/QuadTreeNodeCommon.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using QuadTrees.Helper;
 
@@ -353,9 +354,8 @@ namespace QuadTrees.Common
                 {
                     /* Has few nodes, your children are my children */
 
-                    Dictionary<T, QuadTreeObject<T, TNode>> buffer =
-                        new Dictionary<T, QuadTreeObject<T, TNode>>(MaxObjectsPerNode);
-                    GetAllObjects((a) => buffer.Add(a.Data, a));
+                    Dictionary<T, QuadTreeObject<T, TNode>> buffer = new Dictionary<T, QuadTreeObject<T, TNode>>(MaxObjectsPerNode);
+                    GetAllObjects((ref QuadTreeObject<T, TNode> a) => buffer.Add(a.Data, a));
 
 #if DEBUG
                 Dictionary<T, TNode> oldOwners = buffer.ToDictionary((a) => a.Key, (b) => b.Value.Owner);
@@ -426,7 +426,7 @@ namespace QuadTrees.Common
                 {
                     /* If has an empty child & no more than OptimizeThreshold worth of data - rebuild more optimally */
                     Dictionary<T, QuadTreeObject<T, TNode>> buffer = new Dictionary<T, QuadTreeObject<T, TNode>>();
-                    GetAllObjects((a) => buffer.Add(a.Data, a));
+                    GetAllObjects((ref QuadTreeObject<T, TNode> a) => buffer.Add(a.Data, a));
 
 #if DEBUG
                 Dictionary<T, TNode> oldOwners = buffer.ToDictionary((a) => a.Key, (b) => b.Value.Owner);
@@ -905,7 +905,7 @@ namespace QuadTrees.Common
         public List<T> GetObjects(TQuery searchRect)
         {
             var results = new List<T>();
-            GetObjects(searchRect, results.Add);
+            GetObjects(searchRect, (ref T obj) => results.Add(obj));
             return results;
         }
 
@@ -990,7 +990,99 @@ namespace QuadTrees.Common
         /// </summary>
         /// <param name="searchRect">The Rectangle to find objects in.</param>
         /// <param name="put"></param>
-        public void GetObjects(TQuery searchRect, Action<T> put)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ObjectCount(TQuery searchRect) {
+
+            var count = 0;
+            
+            // We can't do anything if the results list doesn't exist
+            if (QueryContains(searchRect, Rect))
+            {
+                // If the search area completely contains this quad, just get every object this quad and all it's children have
+                count += AllObjectsCount();
+            }
+            else if (QueryIntersects(searchRect, Rect))
+            {
+                // Otherwise, if the quad isn't fully contained, only add objects that intersect with the search rectangle
+                if (_objects != null)
+                {
+                    for (int i = 0; i < _objectCount; i++)
+                    {
+                        var data = _objects[i].Data;
+                        if (CheckIntersects(searchRect, data)) {
+                            count++;
+                        }
+                    }
+                }
+
+                // Get the objects for the search Rectangle from the children
+                if (ChildTl != null)
+                {
+                    Debug.Assert(ChildTl != this);
+                    Debug.Assert(ChildTr != this);
+                    Debug.Assert(ChildBl != this);
+                    Debug.Assert(ChildBr != this);
+                    count += ChildTl.ObjectCount(searchRect);
+                    count += ChildTr.ObjectCount(searchRect);
+                    count += ChildBl.ObjectCount(searchRect);
+                    count += ChildBr.ObjectCount(searchRect);
+                }
+                else
+                {
+                    Debug.Assert(ChildTr == null);
+                    Debug.Assert(ChildBl == null);
+                    Debug.Assert(ChildBr == null);
+                }
+            }
+
+            return count;
+        }
+        
+        /// <summary>
+        /// Get all objects in this Quad, and it's children.
+        /// </summary>
+        /// <param name="put">A reference to a list in which to store the objects.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int AllObjectsCount() {
+            
+            var count = 0;
+            
+            // If this Quad has objects, add them
+            if (_objects != null)
+            {
+                Debug.Assert(_objectCount != 0);
+                Debug.Assert(_objectCount == _objects.Count((a) => a != null));
+
+                for (int i = 0; i < _objectCount; i++)
+                {
+                    if (_objects[i].Owner != this) break; //todo: better?
+                    count++;
+                }
+            }
+            else
+            {
+                Debug.Assert(_objectCount == 0);
+            }
+
+            // If we have children, get their objects too
+            if (ChildTl != null)
+            {
+                count += ChildTl.AllObjectsCount();
+                count += ChildTr.AllObjectsCount();
+                count += ChildBl.AllObjectsCount();
+                count += ChildBr.AllObjectsCount();
+            }
+
+            return count;
+        }
+        
+        /// <summary>
+        /// Get the objects in this tree that intersect with the specified rectangle.
+        /// </summary>
+        /// <param name="searchRect">The Rectangle to find objects in.</param>
+        /// <param name="put"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetObjects(TQuery searchRect, ForObject<T> put)
         {
             // We can't do anything if the results list doesn't exist
             if (QueryContains(searchRect, Rect))
@@ -1008,7 +1100,7 @@ namespace QuadTrees.Common
                         var data = _objects[i].Data;
                         if (CheckIntersects(searchRect, data))
                         {
-                            put(data);
+                            put(ref data);
                         }
                     }
                 }
@@ -1034,17 +1126,18 @@ namespace QuadTrees.Common
             }
         }
 
-
         /// <summary>
         /// Get all objects in this Quad, and it's children.
         /// </summary>
         /// <param name="put">A reference to a list in which to store the objects.</param>
-        public void GetAllObjects(Action<T> put)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetAllObjects(ForObject<T> put)
         {
-            GetAllObjects((a) => put(a.Data));
+            GetAllObjects((ref QuadTreeObject<T, TNode> a) => put(ref a._data));
         }
 
-        public void GetAllObjects(Action<QuadTreeObject<T, TNode>> put)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetAllObjects(ForObject<QuadTreeObject<T, TNode>> put)
         {
             // If this Quad has objects, add them
             if (_objects != null)
@@ -1055,7 +1148,7 @@ namespace QuadTrees.Common
                 for (int i = 0; i < _objectCount; i++)
                 {
                     if (_objects[i].Owner != this) break; //todo: better?
-                    put(_objects[i]);
+                    put(ref _objects[i]);
                 }
             }
             else
@@ -1071,6 +1164,181 @@ namespace QuadTrees.Common
                 ChildBl.GetAllObjects(put);
                 ChildBr.GetAllObjects(put);
             }
+        }
+        
+                /// <summary>
+        /// Get the objects in this tree that intersect with the specified rectangle.
+        /// </summary>
+        /// <param name="searchRect">The RectangleF to find objects in.</param>
+        /// <param name="put"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetObjects<P>(TQuery searchRect, ref P payload, ForObject<P,T> put)
+        {
+            // We can't do anything if the results list doesn't exist
+            if (QueryContains(searchRect, Rect))
+            {
+                // If the search area completely contains this quad, just get every object this quad and all it's children have
+                GetAllObjects(ref payload, put);
+            }
+            else if (QueryIntersects(searchRect, Rect))
+            {
+                // Otherwise, if the quad isn't fully contained, only add objects that intersect with the search rectangle
+                if (_objects != null)
+                {
+                    for (int i = 0; i < _objectCount; i++)
+                    {
+                        var data = _objects[i].Data;
+                        if (CheckIntersects(searchRect, data))
+                        {
+                            put(ref payload, ref data);
+                        }
+                    }
+                }
+
+                // Get the objects for the search RectangleF from the children
+                if (ChildTl != null)
+                {
+                    Debug.Assert(ChildTl != this);
+                    Debug.Assert(ChildTr != this);
+                    Debug.Assert(ChildBl != this);
+                    Debug.Assert(ChildBr != this);
+                    ChildTl.GetObjects(searchRect, ref payload, put);
+                    ChildTr.GetObjects(searchRect, ref payload, put);
+                    ChildBl.GetObjects(searchRect, ref payload, put);
+                    ChildBr.GetObjects(searchRect, ref payload, put);
+                }
+                else
+                {
+                    Debug.Assert(ChildTr == null);
+                    Debug.Assert(ChildBl == null);
+                    Debug.Assert(ChildBr == null);
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Get all objects in this Quad, and it's children.
+        /// </summary>
+        /// <param name="put">A reference to a list in which to store the objects.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetAllObjects<P>(ref P payload, ForObject<P,T> put)
+        {
+            GetAllObjects(ref payload, (ref P load, ref QuadTreeObject<T, TNode> o) => put(ref load, ref o._data));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetAllObjects<P>(ref P payload, ForObject<P, QuadTreeObject<T, TNode>> put)
+        {
+            // If this Quad has objects, add them
+            if (_objects != null)
+            {
+                Debug.Assert(_objectCount != 0);
+                Debug.Assert(_objectCount == _objects.Count((a) => a != null));
+
+                for (int i = 0; i < _objectCount; i++)
+                {
+                    if (_objects[i].Owner != this) break; //todo: better?
+                    put(ref payload, ref _objects[i]);
+                }
+            }
+            else
+            {
+                Debug.Assert(_objectCount == 0);
+            }
+
+            // If we have children, get their objects too
+            if (ChildTl != null)
+            {
+                ChildTl.GetAllObjects(ref payload, put);
+                ChildTr.GetAllObjects(ref payload, put);
+                ChildBl.GetAllObjects(ref payload, put);
+                ChildBr.GetAllObjects(ref payload, put);
+            }
+        }
+        
+        /// <summary>
+        /// Get the objects in this tree that intersect with the specified rectangle.
+        /// </summary>
+        /// <param name="searchRect">The RectangleF to find objects in.</param>
+        /// <param name="put"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetObjects(TQuery searchRect, Span<T> array, int count = 0)
+        {
+            // We can't do anything if the results list doesn't exist
+            if (QueryContains(searchRect, Rect))
+            {
+                // If the search area completely contains this quad, just get every object this quad and all it's children have
+                count = GetAllObjects(array, count);
+            }
+            else if (QueryIntersects(searchRect, Rect))
+            {
+                // Otherwise, if the quad isn't fully contained, only add objects that intersect with the search rectangle
+                if (_objects != null)
+                {
+                    for (int i = 0; i < _objectCount; i++)
+                    {
+                        var data = _objects[i].Data;
+                        if (CheckIntersects(searchRect, data)) {
+                            array[count] = data;
+                            count++;
+                        }
+                    }
+                }
+
+                // Get the objects for the search RectangleF from the children
+                if (ChildTl != null)
+                {
+                    Debug.Assert(ChildTl != this);
+                    Debug.Assert(ChildTr != this);
+                    Debug.Assert(ChildBl != this);
+                    Debug.Assert(ChildBr != this);
+                    count = ChildTl.GetObjects(searchRect, array, count);
+                    count = ChildTr.GetObjects(searchRect, array, count);
+                    count = ChildBl.GetObjects(searchRect, array, count);
+                    count = ChildBr.GetObjects(searchRect, array, count);
+                }
+                else
+                {
+                    Debug.Assert(ChildTr == null);
+                    Debug.Assert(ChildBl == null);
+                    Debug.Assert(ChildBr == null);
+                }
+            }
+
+            return count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetAllObjects(Span<T> array, int count = 0)
+        {
+            // If this Quad has objects, add them
+            if (_objects != null)
+            {
+                Debug.Assert(_objectCount != 0);
+                Debug.Assert(_objectCount == _objects.Count((a) => a != null));
+
+                for (int i = 0; i < _objectCount; i++)
+                {
+                    if (_objects[i].Owner != this) break; //todo: better?
+                    array[count] = _objects[i].Data;
+                    count++;
+                }
+            }
+            else
+            {
+                Debug.Assert(_objectCount == 0);
+            }
+
+            // If we have children, get their objects too
+            if (ChildTl != null)
+            {
+                count = ChildTl.GetAllObjects(array, count);
+                count = ChildTr.GetAllObjects(array, count);
+                count = ChildBl.GetAllObjects(array, count);
+                count = ChildBr.GetAllObjects(array, count);
+            }
+
+            return count;
         }
 
         private Point CalculateBalance(out int top, out int bottom, out int left, out int right)

--- a/QuadTrees/Common/QuadTreeObject.cs
+++ b/QuadTrees/Common/QuadTreeObject.cs
@@ -8,7 +8,7 @@ namespace QuadTrees.Common
     public class QuadTreeObject<T, TPointNode> where TPointNode: class
     {
         private TPointNode _owner;
-        private T _data;
+        internal T _data;
 
         /// <summary>
         /// The wrapped data value

--- a/QuadTrees/QuadTrees.csproj
+++ b/QuadTrees/QuadTrees.csproj
@@ -4,4 +4,8 @@
     <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Background

Im using this library for my game server which uses a data oriented design heavily. Therefore i primarily use pure structs. Those have a lot of advantages, especially they require no memory allocation which is great for intensive quadtree operations. However this lib isnt supporting structs as quadtree objects properly, 

The .GetObject methods are not that great for hot paths, they either require a list which items can not be pre allocated or they offer just a simple action which we can not pass a payload to. In my case this made the queries pretty memory alloc heavy. Furthermore the .Move methods were never intended to work with structs aswell, so i couldnt properly move my quad objects properly which resulted into a "first remove than add" operation to simulate movement. 

## Improvements

Therefore i added a bunch of features into the project and improved/changed some code. 

- `.ObjectCounts(rect);` Is a new method which counts the amount of objects inside a given rectangle and returns its value
- `GetObjects(rect, Span<T> array)` Is a new method which copies all entities within the rect to a pre allocated array ( can also be stack allocated, great for performance ), should make use of the `ObjectCount` method before to allocate an array with the right size
- `GetObjects(rect, Action<T>)` methods were changes to `GetObjects(rect, ForObject<ref T>())` methods which make use of a delegate and references to avoid unecessary object copies and provide direct acess to the entity itself.
- `GetObjects<P>(rect, ForObject<ref P, ref T>())` was added to avoid closure copies and allow passing data to the delegate which than can be used upon the entity. In my case i needed it to cound entities of a certain type inside the quadtree which now can be done easily. 

Also several `MethodImpl` were added before the hot path methods to improve performance by inlining them properly.
I should also notice that using refs is way faster than using ins, ins do always create a security copy and are therefore slower. 

## Tests

Added a few more tests for my extensions i made, all tests do run properly without any issues,
All in all, this request can be accepted without hesitation... but would be great if you could look at the code to tell me if it fits your standards :) 

## Outlook
I havent looked that deep into this lib, but its the only one that fits my needs... so i hope for further performance improvements in the future to squeeze every bit of cpu and ram useage out of this ^^ 